### PR TITLE
Fix apparent MT bug.

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -336,11 +336,13 @@ static Double *lex_sort(int bytes[16], Double *src, Double *trg, Lex_Arg *parmx)
         { x = 0;
           for (i = 0; i < NTHREADS; i++)
             { parmx[i].beg = x;
-              parmx[i].end = x = LEX_zsize*(i+1);
+              if (LEX_zsize*(i+1) <= len) x = LEX_zsize*(i+1);
+              parmx[i].end = x;
               for (j = 0; j < BPOWR; j++)
                 parmx[i].tptr[j] = 0;
             }
           parmx[NTHREADS-1].end = len;
+          //assert(parmx[NTHREADS-1].end >= parmx[NTHREADS-1].beg);
 
           for (j = 0; j < BPOWR; j++)
             { k = (j << NSHIFT);


### PR DESCRIPTION
Not really MT bug. Simple buffer over-run caused one thread
to write into next. Root cause was logic error in dividing
hits into threads when nhits < NTHREADS.

Fixes PacificBiosciences/DALIGNER#9
