### PR TITLE
Fix small bug in lex_sort

### DIFF
--- a/filter.c
+++ b/filter.c
@@ -320,11 +320,13 @@ static Double *lex_sort(int bytes[16], Double *src, Double *trg, Lex_Arg *parmx)
         { x = 0;
           for (i = 0; i < NTHREADS; i++)
             { parmx[i].beg = x;
-              parmx[i].end = x = LEX_zsize*(i+1);
+              if (LEX_zsize*(i+1) <= len) x = LEX_zsize*(i+1);
+              parmx[i].end = x;
               for (j = 0; j < BPOWR; j++)
                 parmx[i].tptr[j] = 0;
             }
           parmx[NTHREADS-1].end = len;
+          //assert(parmx[NTHREADS-1].end >= parmx[NTHREADS-1].beg);
 
           for (j = 0; j < BPOWR; j++)
             { k = (j << NSHIFT);


### PR DESCRIPTION
Hello, Dr. Myers. I'm Christopher Dunn. We met at the SMRT Informatics Developers Conference. (I work with Jason Chin.)

There is a small bug in `filter.c:lex_sort()` when nhits < NTHREADS. The code to split the data between threads fails in this rare corner case. We happened to see it only b/c a user had an example where the complement direction happened to produce exactly 1 hit. It _looks_ like a multi-threading bug, but actually it's only a buffer over-run between thread-data.

With this fix, the code is valgrind-clean on our example (except something in the rewind() syscall, which I assume has nothing to do with daligner).
